### PR TITLE
Split tests

### DIFF
--- a/src/adj_matrix.rs
+++ b/src/adj_matrix.rs
@@ -125,7 +125,7 @@ mod test {
     }
 
     #[test]
-    fn test_unweighted() {
+    fn test_unweighted_trivial() {
         let graph = Graph::<char, f64>::new();
         let am = unweighted(&graph, 1f64, 0f64);
         assert_eq!(am, DMatrix::from_element(0, 0, 0.0));
@@ -134,108 +134,140 @@ mod test {
         graph.add_node('a');
         let am = unweighted(&graph, 1f64, 0f64);
         assert_eq!(am, DMatrix::from_element(1, 1, 0.0));
+    }
 
-        let mut graph = Graph::new_undirected();
-        let a = graph.add_node('a');
-        let b = graph.add_node('b');
-        let c = graph.add_node('c');
-        graph.add_edge(a, b, 1f64);
-        graph.add_edge(a, c, 2f64);
-        graph.add_edge(c, b, 3f64);
-        let am = unweighted(&graph, 1f64, 0f64);
-        assert_eq!(
-            am,
-            Matrix3::new(0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0)
-        );
-
+    #[test]
+    fn test_unweighted_graph_directed() {
         let mut graph = Graph::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = unweighted(&graph, 1f64, 0f64);
+
         assert_eq!(
-            am,
+            unweighted(&graph, 1f64, 0f64),
             Matrix3::new(0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_unweighted_graph_undirected() {
+        let mut graph = Graph::new_undirected();
+        let a = graph.add_node('a');
+        let b = graph.add_node('b');
+        let c = graph.add_node('c');
+
+        graph.add_edge(a, b, 1f64);
+        graph.add_edge(a, c, 2f64);
+        graph.add_edge(c, b, 3f64);
+
+        assert_eq!(
+            unweighted(&graph, 1f64, 0f64),
+            Matrix3::new(0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn test_unweighted_matrix_directed() {
         let mut graph = MatrixGraph::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1i64);
         graph.add_edge(a, c, 2i64);
         graph.add_edge(c, b, 3i64);
-        let am = unweighted(&graph, true, false);
+
         assert_eq!(
-            am,
+            unweighted(&graph, true, false),
             Matrix3::new(false, true, true, false, false, false, false, true, false)
         );
+    }
 
+    #[test]
+    fn test_unweighted_matrix_undirected() {
         let mut graph = MatrixGraph::new_undirected();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = unweighted(&graph, 1f64, 0f64);
+
         assert_eq!(
-            am,
+            unweighted(&graph, 1f64, 0f64),
             Matrix3::new(0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_unweighted_csr() {
         let mut graph = Csr::<char, f64>::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = unweighted(&graph, 1f64, 0f64);
+
         assert_eq!(
-            am,
+            unweighted(&graph, 1f64, 0f64),
             Matrix3::new(0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_unweighted_graphmap_directed() {
         let mut graph = DiGraphMap::<char, f64>::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = unweighted(&graph, 1f64, 0f64);
+
         assert_eq!(
-            am,
+            unweighted(&graph, 1f64, 0f64),
             Matrix3::new(0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_unweighted_graphmap_undirected() {
         let mut graph = UnGraphMap::<char, f64>::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = unweighted(&graph, 1f64, 0f64);
+
         assert_eq!(
-            am,
+            unweighted(&graph, 1f64, 0f64),
             Matrix3::new(0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_unweighted_stable_graph() {
         let mut graph = StableGraph::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = unweighted(&graph, 1f64, 0f64);
+
         assert_eq!(
-            am,
+            unweighted(&graph, 1f64, 0f64),
             Matrix3::new(0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         );
 
@@ -248,108 +280,137 @@ mod test {
     }
 
     #[test]
-    fn test_weighted() {
+    fn test_weighted_graph_undirected() {
         let mut graph = Graph::new_undirected();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = weighted(&graph, 0f64, float_to_scalar);
+
         assert_eq!(
-            am,
+            weighted(&graph, 0f64, float_to_scalar),
             Matrix3::new(0.0, 1.0, 2.0, 1.0, 0.0, 3.0, 2.0, 3.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_weighted_graph_directed() {
         let mut graph = Graph::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, "1.0");
         graph.add_edge(a, c, "2.0");
         graph.add_edge(c, b, "3.0");
-        let am = weighted(&graph, 0f64, str_to_scalar);
+
         assert_eq!(
-            am,
+            weighted(&graph, 0f64, str_to_scalar),
             Matrix3::new(0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_weighted_matrix_undirected() {
         let mut graph = MatrixGraph::new_undirected();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = weighted(&graph, 0f64, float_to_scalar);
+
         assert_eq!(
-            am,
+            weighted(&graph, 0f64, float_to_scalar),
             Matrix3::new(0.0, 1.0, 2.0, 1.0, 0.0, 3.0, 2.0, 3.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_weighted_matrix_directed() {
         let mut graph = MatrixGraph::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = weighted(&graph, 0f64, float_to_scalar);
+
         assert_eq!(
-            am,
+            weighted(&graph, 0f64, float_to_scalar),
             Matrix3::new(0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_weighted_graphmap_undirected() {
         let mut graph = UnGraphMap::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = weighted(&graph, 0f64, float_to_scalar);
+
         assert_eq!(
-            am,
+            weighted(&graph, 0f64, float_to_scalar),
             Matrix3::new(0.0, 1.0, 2.0, 1.0, 0.0, 3.0, 2.0, 3.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_weighted_graphmap_directed() {
         let mut graph = DiGraphMap::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = weighted(&graph, 0f64, float_to_scalar);
+
         assert_eq!(
-            am,
+            weighted(&graph, 0f64, float_to_scalar),
             Matrix3::new(0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_weighted_csr() {
         let mut graph = Csr::<char, f64>::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, 1f64);
         graph.add_edge(a, c, 2f64);
         graph.add_edge(c, b, 3f64);
-        let am = weighted(&graph, 0f64, float_to_scalar);
+
         assert_eq!(
-            am,
+            weighted(&graph, 0f64, float_to_scalar),
             Matrix3::new(0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0)
         );
+    }
 
+    #[test]
+    fn test_weighted_stable_graph() {
         let mut graph = StableGraph::new();
         let a = graph.add_node('a');
         let b = graph.add_node('b');
         let c = graph.add_node('c');
+
         graph.add_edge(a, b, "1.0");
         graph.add_edge(a, c, "2.0");
         graph.add_edge(c, b, "3.0");
-        let am = weighted(&graph, 0f64, str_to_scalar);
+
         assert_eq!(
-            am,
+            weighted(&graph, 0f64, str_to_scalar),
             Matrix3::new(0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0)
         );
 
@@ -359,12 +420,14 @@ mod test {
             am,
             Matrix3::new(0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         );
+
         graph.remove_node(a);
         let am = weighted(&graph, 0f64, str_to_scalar);
         assert_eq!(
             am,
             Matrix3::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         );
+
         graph.remove_node(c);
         let am = weighted(&graph, 0f64, str_to_scalar);
         assert_eq!(am, DMatrix::from_element(0, 0, 0.0));

--- a/src/connect/articulation_points.rs
+++ b/src/connect/articulation_points.rs
@@ -125,7 +125,7 @@ mod tests {
     use petgraph::graph::UnGraph;
 
     #[test]
-    fn test_articulation_points() {
+    fn test_articulation_points_case_1() {
         let mut g = UnGraph::<i8, i8>::new_undirected();
         assert_eq!(articulation_points(&g), vec![]);
 
@@ -153,7 +153,10 @@ mod tests {
 
         g.add_edge(n3, n0, 5);
         assert_eq!(articulation_points(&g), vec![n3]);
+    }
 
+    #[test]
+    fn test_articulation_points_case_2() {
         let mut g = UnGraph::new_undirected();
         let n0 = g.add_node(());
         let n1 = g.add_node(());

--- a/src/connect/find_bridges.rs
+++ b/src/connect/find_bridges.rs
@@ -103,7 +103,7 @@ mod tests {
     use petgraph::graph::UnGraph;
 
     #[test]
-    fn test_find_bridges() {
+    fn test_find_bridges_case_1() {
         let mut g = UnGraph::<i8, i8>::new_undirected();
         assert_eq!(find_bridges(&g), vec![]);
 
@@ -131,7 +131,10 @@ mod tests {
 
         g.add_edge(n3, n0, 5);
         assert_eq!(find_bridges(&g), vec![(n3, n4)]);
+    }
 
+    #[test]
+    fn test_find_bridges_case_2() {
         let mut g = UnGraph::new_undirected();
         let n0 = g.add_node(());
         let n1 = g.add_node(());

--- a/src/generate/complement.rs
+++ b/src/generate/complement.rs
@@ -71,7 +71,8 @@ mod tests {
     use petgraph::graph::Graph;
     use petgraph::Directed;
 
-    fn graph1() -> Graph<(), ()> {
+    #[test]
+    fn test_complement() {
         let mut graph = Graph::<(), ()>::new();
         let n0 = graph.add_node(());
         let n1 = graph.add_node(());
@@ -85,16 +86,11 @@ mod tests {
         graph.add_edge(n1, n3, ());
         graph.add_edge(n3, n1, ());
 
-        graph
-    }
-
-    #[test]
-    fn test_complement() {
         let expected = vec![(0, 2), (2, 0), (0, 3), (3, 0), (2, 3), (3, 2)]
             .into_iter()
             .collect::<HashSet<(usize, usize)>>();
 
-        assert_eq!(complement(&graph1()), expected);
+        assert_eq!(complement(&graph), expected);
     }
 
     #[test]

--- a/src/generate/randomg.rs
+++ b/src/generate/randomg.rs
@@ -258,14 +258,16 @@ pub fn random_weighted_ungraph<K: SampleUniform + PartialOrd + Copy>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use petgraph::Directed;
-    use petgraph::Graph;
 
     #[test]
     fn test_random_digraph() {
         assert!(random_digraph(5, 10).is_ok());
         assert!(random_digraph(0, 0).is_ok());
         assert!(random_digraph(50, 1000).is_ok());
+    }
+
+    #[test]
+    fn test_random_digraph_error() {
         assert_eq!(
             random_digraph(5, 100),
             Err(EdgeNumberError {
@@ -274,10 +276,6 @@ mod test {
                 max_edges: 20,
             })
         );
-        println!(
-            "{:?}",
-            &Graph::<(), (), Directed, usize>::from_edges(random_digraph(4, 11).unwrap())
-        );
     }
 
     #[test]
@@ -285,6 +283,10 @@ mod test {
         assert!(random_weighted_digraph(5, 10, 10u8, 100u8).is_ok());
         assert!(random_weighted_digraph(0, 0, -100i64, 100i64).is_ok());
         assert!(random_weighted_digraph(50, 1000, 0.0, 0.001).is_ok());
+    }
+
+    #[test]
+    fn test_random_weighted_digraph_error() {
         assert_eq!(
             random_weighted_digraph(5, 100, -10.0, 10.0),
             Err(EdgeNumberError {
@@ -293,15 +295,6 @@ mod test {
                 max_edges: 20,
             })
         );
-        println!(
-            "{:?}",
-            &Graph::<(), f32, Directed, usize>::from_edges(
-                random_weighted_digraph(4, 11, -10.0, 10.0)
-                    .unwrap()
-                    .into_iter()
-                    .map(|(edge, w)| (edge.0, edge.1, w))
-            )
-        );
     }
 
     #[test]
@@ -309,6 +302,10 @@ mod test {
         assert!(random_ungraph(5, 10).is_ok());
         assert!(random_ungraph(0, 0).is_ok());
         assert!(random_ungraph(50, 1000).is_ok());
+    }
+
+    #[test]
+    fn test_random_ungraph_error() {
         assert_eq!(
             random_ungraph(5, 100),
             Err(EdgeNumberError {
@@ -317,10 +314,6 @@ mod test {
                 max_edges: 10,
             })
         );
-        println!(
-            "{:?}",
-            &Graph::<(), (), Directed, usize>::from_edges(random_ungraph(4, 5).unwrap())
-        );
     }
 
     #[test]
@@ -328,6 +321,10 @@ mod test {
         assert!(random_weighted_ungraph(5, 10, 10u8, 100u8).is_ok());
         assert!(random_weighted_ungraph(0, 0, -100i32, 100i32).is_ok());
         assert!(random_weighted_ungraph(50, 500, 0.0, 0.001).is_ok());
+    }
+
+    #[test]
+    fn test_random_weighted_ungraph_error() {
         assert_eq!(
             random_weighted_ungraph(5, 100, -10.0, 10.0),
             Err(EdgeNumberError {
@@ -335,15 +332,6 @@ mod test {
                 nedges: 100,
                 max_edges: 10,
             })
-        );
-        println!(
-            "{:?}",
-            &Graph::<(), f32, Directed, usize>::from_edges(
-                random_weighted_ungraph(4, 5, -10.0, 10.0)
-                    .unwrap()
-                    .into_iter()
-                    .map(|(edge, w)| (edge.0, edge.1, w))
-            )
         );
     }
 }

--- a/src/mst/boruvka.rs
+++ b/src/mst/boruvka.rs
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn test_with_prim_random() {
+    fn test_boruvka_with_prim_random_50_1000() {
         for _ in 0..20 {
             let graph: UnGraph<(), f64, usize> = UnGraph::from_edges(
                 random_weighted_ungraph(50, 1000, -100.0, 100.0)
@@ -186,30 +186,19 @@ mod tests {
                     .into_iter()
                     .map(|(edge, w)| (edge.0, edge.1, w)),
             );
-            let mut boruvka_output = boruvka(&graph, |edge| *edge.weight());
-            let mut prim_output = prim(&graph, |edge| *edge.weight())
+
+            let boruvka_output = boruvka(&graph, |edge| *edge.weight());
+            let prim_output = prim(&graph, |edge| *edge.weight())
                 .into_iter()
                 .collect::<HashSet<(usize, usize)>>();
 
-            let mut temp = HashSet::<(usize, usize)>::new();
-            for edge in boruvka_output.iter() {
-                temp.insert((edge.1, edge.0));
-            }
-            for edge in temp.into_iter() {
-                boruvka_output.insert(edge);
-            }
-
-            let mut temp = HashSet::<(usize, usize)>::new();
-            for edge in prim_output.iter() {
-                temp.insert((edge.1, edge.0));
-            }
-            for edge in temp.into_iter() {
-                prim_output.insert(edge);
-            }
-
-            assert_eq!(boruvka_output, prim_output);
+            compare(boruvka_output, prim_output);
         }
+    }
 
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_boruvka_with_prim_random_500_250() {
         for _ in 0..20 {
             let graph: UnGraph<(), f64, usize> = UnGraph::from_edges(
                 random_weighted_ungraph(500, 250, -100.0, 100.0)
@@ -217,30 +206,18 @@ mod tests {
                     .into_iter()
                     .map(|(edge, w)| (edge.0, edge.1, w)),
             );
-            let mut boruvka_output = boruvka(&graph, |edge| *edge.weight());
-            let mut prim_output = prim(&graph, |edge| *edge.weight())
+
+            let boruvka_output = boruvka(&graph, |edge| *edge.weight());
+            let prim_output = prim(&graph, |edge| *edge.weight())
                 .into_iter()
                 .collect::<HashSet<(usize, usize)>>();
 
-            let mut temp = HashSet::<(usize, usize)>::new();
-            for edge in boruvka_output.iter() {
-                temp.insert((edge.1, edge.0));
-            }
-            for edge in temp.into_iter() {
-                boruvka_output.insert(edge);
-            }
-
-            let mut temp = HashSet::<(usize, usize)>::new();
-            for edge in prim_output.iter() {
-                temp.insert((edge.1, edge.0));
-            }
-            for edge in temp.into_iter() {
-                prim_output.insert(edge);
-            }
-
-            assert_eq!(boruvka_output, prim_output);
+            compare(boruvka_output, prim_output);
         }
-
+    }
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_boruvka_with_prim_random_10_30() {
         for _ in 0..100 {
             let graph: UnGraph<(), f64, usize> = UnGraph::from_edges(
                 random_weighted_ungraph(10, 30, -100.0, 100.0)
@@ -248,28 +225,26 @@ mod tests {
                     .into_iter()
                     .map(|(edge, w)| (edge.0, edge.1, w)),
             );
-            let mut boruvka_output = boruvka(&graph, |edge| *edge.weight());
-            let mut prim_output = prim(&graph, |edge| *edge.weight())
+
+            let boruvka_output = boruvka(&graph, |edge| *edge.weight());
+            let prim_output = prim(&graph, |edge| *edge.weight())
                 .into_iter()
                 .collect::<HashSet<(usize, usize)>>();
 
-            let mut temp = HashSet::<(usize, usize)>::new();
-            for edge in boruvka_output.iter() {
-                temp.insert((edge.1, edge.0));
-            }
-            for edge in temp.into_iter() {
-                boruvka_output.insert(edge);
-            }
-
-            let mut temp = HashSet::<(usize, usize)>::new();
-            for edge in prim_output.iter() {
-                temp.insert((edge.1, edge.0));
-            }
-            for edge in temp.into_iter() {
-                prim_output.insert(edge);
-            }
-
-            assert_eq!(boruvka_output, prim_output);
+            compare(boruvka_output, prim_output);
         }
+    }
+
+    fn compare(
+        mut boruvka_edges: HashSet<(usize, usize)>,
+        mut prim_edges: HashSet<(usize, usize)>,
+    ) {
+        let temp: HashSet<(usize, usize)> = boruvka_edges.iter().map(|&(a, b)| (b, a)).collect();
+        boruvka_edges.extend(temp);
+
+        let temp: HashSet<(usize, usize)> = prim_edges.iter().map(|&(a, b)| (b, a)).collect();
+        prim_edges.extend(temp);
+
+        assert_eq!(boruvka_edges, prim_edges);
     }
 }

--- a/src/shortest_path/johnson.rs
+++ b/src/shortest_path/johnson.rs
@@ -279,10 +279,6 @@ mod tests {
     }
 
     fn graph5() -> Graph<(), f32> {
-        Graph::<(), f32>::new()
-    }
-
-    fn graph6() -> Graph<(), f32> {
         let mut graph = Graph::<(), f32>::new();
         let n0 = graph.add_node(());
         let n1 = graph.add_node(());
@@ -295,9 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn test_johnson() {
-        let inf = f32::INFINITY;
-
+    fn test_johnson_fully_connected() {
         assert_eq!(
             johnson(&graph1(), |edge| *edge.weight()),
             Ok(vec![
@@ -308,6 +302,11 @@ mod tests {
                 vec![18.0, 15.0, 34.0, 20.0, 0.0]
             ])
         );
+    }
+
+    #[test]
+    fn test_johnson() {
+        let inf = f32::INFINITY;
 
         assert_eq!(
             johnson(&graph2(), |edge| *edge.weight()),
@@ -320,14 +319,31 @@ mod tests {
                 vec![inf, -4.0, -9.0, 11.0, 1.0, 0.0],
             ])
         );
+    }
 
-        // Graphs with negative cycle
+    #[test]
+    fn test_johnson_empty_graph() {
+        let graph = Graph::<(), f32>::new();
+        assert_eq!(johnson(&graph, |edge| *edge.weight()), Ok(vec![]));
+    }
+
+    #[test]
+    fn test_johnson_single_node() {
+        assert_eq!(
+            johnson(&graph4(), |edge| *edge.weight()),
+            Ok(vec![vec![0.0]])
+        );
+    }
+
+    #[test]
+    fn test_johnson_negative_cycle() {
         assert_eq!(
             johnson(&graph3(), |edge| *edge.weight()),
             Err(NegativeCycle {})
         );
+
         assert_eq!(
-            johnson(&graph6(), |edge| *edge.weight()),
+            johnson(&graph5(), |edge| *edge.weight()),
             Err(NegativeCycle {})
         );
 
@@ -337,13 +353,6 @@ mod tests {
             johnson(&graph, |edge| *edge.weight()),
             Err(NegativeCycle {})
         );
-
-        // Edge cases
-        assert_eq!(
-            johnson(&graph4(), |edge| *edge.weight()),
-            Ok(vec![vec![0.0]])
-        );
-        assert_eq!(johnson(&graph5(), |edge| *edge.weight()), Ok(vec![]));
     }
 
     #[test]

--- a/src/shortest_path/seidel.rs
+++ b/src/shortest_path/seidel.rs
@@ -240,10 +240,6 @@ mod tests {
         graph
     }
 
-    fn graph4() -> Graph<(), f32> {
-        Graph::<(), f32>::new()
-    }
-
     #[test]
     fn test_apd() {
         assert_eq!(
@@ -272,22 +268,28 @@ mod tests {
                 vec![2, 1, 1, 0],
             ]
         );
+    }
 
-        // Edge cases
+    #[test]
+    fn test_apd_empty_graph() {
+        let graph = Graph::<(), f32>::new();
+        assert_eq!(
+            apd(unweighted(&graph, 1f32, 0.0))
+                .row_iter()
+                .map(|row| row.into_iter().copied().collect::<Vec<f32>>())
+                .collect::<Vec<Vec<f32>>>(),
+            Vec::<Vec<f32>>::new()
+        );
+    }
+
+    #[test]
+    fn test_apd_single_edge() {
         assert_eq!(
             apd(unweighted(&graph3(), 1f64, 0.0))
                 .row_iter()
                 .map(|row| row.into_iter().copied().collect::<Vec<f64>>())
                 .collect::<Vec<Vec<f64>>>(),
             vec![vec![0.0, 1.0], vec![1.0, 0.0]]
-        );
-
-        assert_eq!(
-            apd(unweighted(&graph4(), 1f32, 0.0))
-                .row_iter()
-                .map(|row| row.into_iter().copied().collect::<Vec<f32>>())
-                .collect::<Vec<Vec<f32>>>(),
-            Vec::<Vec<f32>>::new()
         );
     }
 
@@ -339,10 +341,16 @@ mod tests {
                 vec![2, 1, 1, 0],
             ]
         );
+    }
 
-        // Edge cases
+    #[test]
+    fn test_seidel_single_edge() {
         assert_eq!(seidel(&graph3()), vec![vec![0, 1], vec![1, 0]]);
-        assert_eq!(seidel(&graph4()), Vec::<Vec<u32>>::new());
+    }
+
+    #[test]
+    fn test_seidel_empty_graph() {
+        assert_eq!(seidel(&Graph::<(), f32>::new()), Vec::<Vec<u32>>::new());
     }
 
     #[test]

--- a/src/shortest_path/shortest_distances.rs
+++ b/src/shortest_path/shortest_distances.rs
@@ -143,7 +143,10 @@ mod tests {
             shortest_distances(&graph, graph.from_index(11)),
             vec![inf, inf, inf, 2.0, 3.0, inf, 1.0, 2.0, 3.0, inf, 1.0, 0.0]
         );
+    }
 
+    #[test]
+    fn shortest_distances_strongly_connected() {
         let mut graph = Graph::<u8, ()>::new();
         let n0 = graph.add_node(0);
         let n1 = graph.add_node(1);

--- a/src/shortest_path/spfa.rs
+++ b/src/shortest_path/spfa.rs
@@ -125,7 +125,84 @@ mod tests {
     use petgraph::Directed;
     use rand::Rng;
 
-    fn graph1() -> Graph<(), f32> {
+    fn graph1() -> Graph<(), f64> {
+        let mut graph = Graph::<(), f64>::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        let n3 = graph.add_node(());
+
+        graph.add_edge(n0, n1, 10.0);
+        graph.add_edge(n0, n2, 5.0);
+        graph.add_edge(n1, n2, 2.0);
+        graph.add_edge(n2, n3, -10.0);
+        graph.add_edge(n3, n1, -1.0);
+        graph.add_edge(n1, n3, 16.0);
+
+        graph
+    }
+
+    fn graph2() -> Graph<(), f32> {
+        let mut graph = Graph::<(), f32>::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+
+        graph.add_edge(n0, n1, 1.0);
+        graph.add_edge(n1, n0, -10.0);
+        graph.add_edge(n2, n2, 5.0);
+        graph
+    }
+
+    #[test]
+    fn test_spfa() {
+        let inf = f32::INFINITY;
+
+        let mut graph = Graph::<(), f32>::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        let n3 = graph.add_node(());
+        let n4 = graph.add_node(());
+        let n5 = graph.add_node(());
+
+        graph.add_edge(n0, n1, 1.0);
+        graph.add_edge(n5, n1, -4.0);
+        graph.add_edge(n1, n4, 5.0);
+        graph.add_edge(n4, n1, 5.0);
+        graph.add_edge(n2, n1, 8.0);
+        graph.add_edge(n4, n3, 10.0);
+        graph.add_edge(n3, n2, 0.0);
+        graph.add_edge(n3, n2, -20.0);
+
+        assert_eq!(
+            spfa(&graph, 0.into()).unwrap().0,
+            vec![0.0, 1.0, -4.0, 16.0, 6.0, inf]
+        );
+        assert_eq!(
+            spfa(&graph, 1.into()).unwrap().0,
+            vec![inf, 0.0, -5.0, 15.0, 5.0, inf]
+        );
+        assert_eq!(
+            spfa(&graph, 2.into()).unwrap().0,
+            vec![inf, 8.0, 0.0, 23.0, 13.0, inf]
+        );
+        assert_eq!(
+            spfa(&graph, 3.into()).unwrap().0,
+            vec![inf, -12.0, -20.0, 0.0, -7.0, inf]
+        );
+        assert_eq!(
+            spfa(&graph, 4.into()).unwrap().0,
+            vec![inf, -2.0, -10.0, 10.0, 0.0, inf]
+        );
+        assert_eq!(
+            spfa(&graph, 5.into()).unwrap().0,
+            vec![inf, -4.0, -9.0, 11.0, 1.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn test_spfa_strongly_connected() {
         let mut graph = Graph::<(), f32>::new();
         let n0 = graph.add_node(());
         let n1 = graph.add_node(());
@@ -148,124 +225,39 @@ mod tests {
         graph.add_edge(n4, n1, 15.0);
         graph.add_edge(n4, n3, 20.0);
 
-        graph
-    }
-
-    fn graph2() -> Graph<(), f32> {
-        let mut graph = Graph::<(), f32>::new();
-        let n0 = graph.add_node(());
-        let n1 = graph.add_node(());
-        let n2 = graph.add_node(());
-        let n3 = graph.add_node(());
-        let n4 = graph.add_node(());
-        let n5 = graph.add_node(());
-
-        graph.add_edge(n0, n1, 1.0);
-        graph.add_edge(n5, n1, -4.0);
-        graph.add_edge(n1, n4, 5.0);
-        graph.add_edge(n4, n1, 5.0);
-        graph.add_edge(n2, n1, 8.0);
-        graph.add_edge(n4, n3, 10.0);
-        graph.add_edge(n3, n2, 0.0);
-        graph.add_edge(n3, n2, -20.0);
-
-        graph
-    }
-
-    fn graph3() -> Graph<(), f64> {
-        let mut graph = Graph::<(), f64>::new();
-        let n0 = graph.add_node(());
-        let n1 = graph.add_node(());
-        let n2 = graph.add_node(());
-        let n3 = graph.add_node(());
-
-        graph.add_edge(n0, n1, 10.0);
-        graph.add_edge(n0, n2, 5.0);
-        graph.add_edge(n1, n2, 2.0);
-        graph.add_edge(n2, n3, -10.0);
-        graph.add_edge(n3, n1, -1.0);
-        graph.add_edge(n1, n3, 16.0);
-
-        graph
-    }
-
-    fn graph4() -> Graph<(), f32> {
-        let mut graph = Graph::<(), f32>::new();
-        graph.add_node(());
-        graph
-    }
-
-    fn graph5() -> Graph<(), f32> {
-        let mut graph = Graph::<(), f32>::new();
-        let n0 = graph.add_node(());
-        let n1 = graph.add_node(());
-        let n2 = graph.add_node(());
-
-        graph.add_edge(n0, n1, 1.0);
-        graph.add_edge(n1, n0, -10.0);
-        graph.add_edge(n2, n2, 5.0);
-        graph
-    }
-
-    #[test]
-    fn test_spfa() {
-        let inf = f32::INFINITY;
-
-        // graph1
-        println!("{:?}", spfa(&graph1(), 4.into()));
         assert_eq!(
-            spfa(&graph1(), 0.into()).unwrap().0,
+            spfa(&graph, 0.into()).unwrap().0,
             vec![0.0, 33.0, 52.0, 38.0, 18.0]
         );
         assert_eq!(
-            spfa(&graph1(), 1.into()).unwrap().0,
+            spfa(&graph, 1.into()).unwrap().0,
             vec![33.0, 0.0, 20.0, 6.0, 15.0]
         );
         assert_eq!(
-            spfa(&graph1(), 2.into()).unwrap().0,
+            spfa(&graph, 2.into()).unwrap().0,
             vec![52.0, 20.0, 0.0, 14.0, 34.0]
         );
         assert_eq!(
-            spfa(&graph1(), 3.into()).unwrap().0,
+            spfa(&graph, 3.into()).unwrap().0,
             vec![38.0, 6.0, 14.0, 0.0, 20.0]
         );
         assert_eq!(
-            spfa(&graph1(), 4.into()).unwrap().0,
+            spfa(&graph, 4.into()).unwrap().0,
             vec![18.0, 15.0, 34.0, 20.0, 0.0]
         );
+    }
 
-        // graph 2
-        assert_eq!(
-            spfa(&graph2(), 0.into()).unwrap().0,
-            vec![0.0, 1.0, -4.0, 16.0, 6.0, inf]
-        );
-        assert_eq!(
-            spfa(&graph2(), 1.into()).unwrap().0,
-            vec![inf, 0.0, -5.0, 15.0, 5.0, inf]
-        );
-        assert_eq!(
-            spfa(&graph2(), 2.into()).unwrap().0,
-            vec![inf, 8.0, 0.0, 23.0, 13.0, inf]
-        );
-        assert_eq!(
-            spfa(&graph2(), 3.into()).unwrap().0,
-            vec![inf, -12.0, -20.0, 0.0, -7.0, inf]
-        );
-        assert_eq!(
-            spfa(&graph2(), 4.into()).unwrap().0,
-            vec![inf, -2.0, -10.0, 10.0, 0.0, inf]
-        );
-        assert_eq!(
-            spfa(&graph2(), 5.into()).unwrap().0,
-            vec![inf, -4.0, -9.0, 11.0, 1.0, 0.0]
-        );
+    #[test]
+    fn test_spfa_single_node() {
+        let mut graph = Graph::<(), f32>::new();
+        graph.add_node(());
+        assert_eq!(spfa(&graph, 0.into()).unwrap().0, vec![0.0]);
+    }
 
-        // Graphs with negative cycle
-        assert!(spfa(&graph3(), 0.into()).is_err());
-        assert!(spfa(&graph5(), 0.into()).is_err());
-
-        // |V| = 1
-        assert_eq!(spfa(&graph4(), 0.into()).unwrap().0, vec![0.0]);
+    #[test]
+    fn test_spfa_negative_cycle() {
+        assert!(spfa(&graph1(), 0.into()).is_err());
+        assert!(spfa(&graph2(), 0.into()).is_err());
     }
 
     #[test]

--- a/src/spec/laplacian.rs
+++ b/src/spec/laplacian.rs
@@ -147,7 +147,7 @@ mod test {
     use petgraph::graph::{Graph, UnGraph};
 
     #[test]
-    fn test_laplacian_matrix() {
+    fn test_laplacian_matrix_ungraph() {
         let mut graph = UnGraph::<u32, f32>::new_undirected();
         let n0 = graph.add_node(0);
         let n1 = graph.add_node(1);
@@ -178,7 +178,10 @@ mod test {
                 -30.0, 0.0, -50.0, 80.0,
             )
         );
+    }
 
+    #[test]
+    fn test_laplacian_matrix_digraph() {
         let mut digraph = Graph::<u32, f32>::new();
         let n0 = digraph.add_node(0);
         let n1 = digraph.add_node(1);

--- a/src/spec/prufer.rs
+++ b/src/spec/prufer.rs
@@ -152,69 +152,53 @@ mod test {
     use super::*;
     use petgraph::graph::UnGraph;
 
-    fn graph1() -> UnGraph<u8, f32> {
-        let mut graph = UnGraph::<u8, f32>::new_undirected();
-        let n0 = graph.add_node(0);
-        let n1 = graph.add_node(1);
-        let n2 = graph.add_node(2);
-        let n3 = graph.add_node(3);
-        let n4 = graph.add_node(4);
-        let n5 = graph.add_node(5);
-        let n6 = graph.add_node(6);
-        let n7 = graph.add_node(7);
-        let n8 = graph.add_node(8);
-        let n9 = graph.add_node(9);
-
-        graph.add_edge(n0, n1, 1.0);
-        graph.add_edge(n0, n4, 2.0);
-        graph.add_edge(n0, n6, 3.0);
-        graph.add_edge(n6, n5, 4.0);
-        graph.add_edge(n1, n2, 5.0);
-        graph.add_edge(n1, n3, 6.0);
-        graph.add_edge(n0, n9, 7.0);
-        graph.add_edge(n9, n7, 8.0);
-        graph.add_edge(n8, n9, 9.0);
-
-        graph
-    }
-
-    fn graph2() -> UnGraph<u8, ()> {
-        UnGraph::from_edges([(0, 1), (0, 2), (1, 3), (0, 4), (1, 5)])
-    }
-
-    fn graph3() -> UnGraph<u8, ()> {
-        UnGraph::from_edges([(0, 3), (0, 5), (3, 4), (3, 1), (3, 2)])
-    }
-
-    fn graph4() -> UnGraph<u8, ()> {
-        UnGraph::from_edges([(2, 0), (2, 1), (2, 3), (2, 4), (2, 5)])
-    }
-
     #[test]
-    fn test_prufer_code() {
-        let graph = graph1();
+    fn test_prufer_code_case_1() {
+        let graph = UnGraph::<u32, ()>::from_edges([
+            (0, 1),
+            (0, 4),
+            (0, 6),
+            (6, 5),
+            (1, 2),
+            (1, 3),
+            (0, 9),
+            (9, 7),
+            (8, 9),
+        ]);
 
         let ix = |i| graph.from_index(i);
         assert_eq!(
             prufer_code(&graph),
             vec![ix(1), ix(1), ix(0), ix(0), ix(6), ix(0), ix(9), ix(9)]
         );
+    }
 
-        let graph = graph2();
+    #[test]
+    fn test_prufer_code_case_2() {
+        let graph = UnGraph::<u32, ()>::from_edges([(0, 1), (0, 2), (1, 3), (0, 4), (1, 5)]);
+
         let ix = |i| graph.from_index(i);
         assert_eq!(prufer_code(&graph), vec![ix(0), ix(1), ix(0), ix(1)]);
+    }
 
-        let graph = graph3();
+    #[test]
+    fn test_prufer_code_case_3() {
+        let graph = UnGraph::<u32, ()>::from_edges([(0, 3), (0, 5), (3, 4), (3, 1), (3, 2)]);
+
         let ix = |i| graph.from_index(i);
         assert_eq!(prufer_code(&graph), vec![ix(3), ix(3), ix(3), ix(0)]);
+    }
 
-        let graph = graph4();
+    #[test]
+    fn test_prufer_code_case_4() {
+        let graph = UnGraph::<u32, ()>::from_edges([(2, 0), (2, 1), (2, 3), (2, 4), (2, 5)]);
+
         let ix = |i| graph.from_index(i);
         assert_eq!(prufer_code(&graph), vec![ix(2), ix(2), ix(2), ix(2)]);
     }
 
     #[test]
-    fn test_prufer_decode() {
+    fn test_prufer_decode_case_1() {
         assert_eq!(
             prufer_decode(&[1, 1, 0, 0, 6, 0, 9, 9]),
             vec![
@@ -229,19 +213,33 @@ mod test {
                 (8, 9)
             ],
         );
+    }
+    #[test]
+    fn test_prufer_decode_case_2() {
         assert_eq!(
             prufer_decode(&[0, 1, 0, 1]),
             vec![(2, 0), (3, 1), (4, 0), (0, 1), (1, 5)]
         );
+    }
+
+    #[test]
+    fn test_prufer_decode_case_3() {
         assert_eq!(
             prufer_decode(&[3, 3, 3, 0]),
             vec![(1, 3), (2, 3), (4, 3), (3, 0), (0, 5)]
         );
+    }
+
+    #[test]
+    fn test_prufer_decode_case_4() {
         assert_eq!(
             prufer_decode(&[2, 2, 2, 2]),
             vec![(0, 2), (1, 2), (3, 2), (4, 2), (2, 5)]
         );
+    }
 
+    #[test]
+    fn test_prufer_decode_no_graph() {
         assert_eq!(prufer_decode(&[0, 1, 100, 200]), vec![]);
     }
 }

--- a/src/spec/st.rs
+++ b/src/spec/st.rs
@@ -94,7 +94,7 @@ mod test {
     #[test]
     #[cfg_attr(miri, ignore)]
     // Ignore it because MIRI finds an error in the safe nalgebra API. This requires separate clarifications.
-    fn test_count_spanning_trees() {
+    fn test_count_spanning_trees_ungraph() {
         let mut graph = UnGraph::<u32, f32>::new_undirected();
         let n0 = graph.add_node(0);
         assert_eq!(count_spanning_trees(&graph, n0), 1);
@@ -121,7 +121,12 @@ mod test {
         assert_eq!(count_spanning_trees(&graph, n1), 13);
         assert_eq!(count_spanning_trees(&graph, n2), 13);
         assert_eq!(count_spanning_trees(&graph, n3), 13);
+    }
 
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    // Ignore it because MIRI finds an error in the safe nalgebra API. This require separate clarifications.
+    fn test_count_spanning_trees_digraph() {
         let mut digraph = Graph::<u32, f32>::new();
         let n0 = digraph.add_node(0);
         assert_eq!(count_spanning_trees(&digraph, n0), 1);


### PR DESCRIPTION
Split complex tests into smaller tests to increase the readability and transparency of testing.